### PR TITLE
gstreamer 1.22.3

### DIFF
--- a/recipe/install_base_plugins.bat
+++ b/recipe/install_base_plugins.bat
@@ -9,7 +9,8 @@ set "LIBRARY_PREFIX_M=%LIBRARY_PREFIX:\=/%"
 
 cd plugins_base
 
-meson setup builddir --wrap-mode=nofallback --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Dexamples=disabled -Dintrospection=enabled -Dtests=disabled
+:: disable introspection because of a debug warning introduced in glib 2.67.2 that breaks win64 builds; glib 2.72.2 fixes this.
+meson setup builddir --wrap-mode=nofallback --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Dexamples=disabled -Dintrospection=disabled -Dtests=disabled
 if errorlevel 1 exit 1
 
 ninja -v -C builddir -j %CPU_COUNT%

--- a/recipe/install_base_plugins.bat
+++ b/recipe/install_base_plugins.bat
@@ -9,8 +9,7 @@ set "LIBRARY_PREFIX_M=%LIBRARY_PREFIX:\=/%"
 
 cd plugins_base
 
-:: disable introspection because of a debug warning introduced in glib 2.67.2 that breaks win64 builds; glib 2.72.2 fixes this.
-meson setup builddir --wrap-mode=nofallback --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Dexamples=disabled -Dintrospection=disabled -Dtests=disabled
+meson setup builddir --wrap-mode=nofallback --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Dexamples=disabled -Dintrospection=enabled -Dtests=disabled
 if errorlevel 1 exit 1
 
 ninja -v -C builddir -j %CPU_COUNT%

--- a/recipe/install_gstreamer.bat
+++ b/recipe/install_gstreamer.bat
@@ -7,6 +7,12 @@ set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig;%B
 :: get mixed path (forward slash) form of prefix so host prefix replacement works
 set "LIBRARY_PREFIX_M=%LIBRARY_PREFIX:\=/%"
 
+findstr /m "C:/ci_310/glib_1642686432177/_h_env/Library/lib/z.lib" "%LIBRARY_LIB%\pkgconfig\gio-2.0.pc"
+if %errorlevel%==0 (
+    :: our current glib gio-2.0.pc has zlib dependency set as an absolute path. 
+    powershell -Command "(gc %LIBRARY_LIB%\pkgconfig\gio-2.0.pc) -replace 'Requires:', 'Requires: zlib,' | Out-File -encoding ASCII %LIBRARY_LIB%\pkgconfig\gio-2.0.pc"
+    powershell -Command "(gc %LIBRARY_LIB%\pkgconfig\gio-2.0.pc) -replace 'C:/ci_310/glib_1642686432177/_h_env/Library/lib/z.lib', '' | Out-File -encoding ASCII %LIBRARY_LIB%\pkgconfig\gio-2.0.pc"
+)
 
 meson setup builddir --wrap-mode=nofallback --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Dexamples=disabled -Dintrospection=enabled -Dtests=disabled
 if errorlevel 1 exit 1

--- a/recipe/install_gstreamer.bat
+++ b/recipe/install_gstreamer.bat
@@ -14,8 +14,7 @@ if %errorlevel%==0 (
     powershell -Command "(gc %LIBRARY_LIB%\pkgconfig\gio-2.0.pc) -replace 'C:/ci_310/glib_1642686432177/_h_env/Library/lib/z.lib', '' | Out-File -encoding ASCII %LIBRARY_LIB%\pkgconfig\gio-2.0.pc"
 )
 
-:: disable introspection because of a debug warning introduced in glib 2.67.2 that breaks win64 builds; glib 2.72.2 fixes this.
-meson setup builddir --wrap-mode=nofallback --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Dexamples=disabled -Dintrospection=disabled -Dtests=disabled
+meson setup builddir --wrap-mode=nofallback --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Dexamples=disabled -Dintrospection=enabled -Dtests=disabled
 if errorlevel 1 exit 1
 
 ninja -v -C builddir -j %CPU_COUNT%

--- a/recipe/install_gstreamer.bat
+++ b/recipe/install_gstreamer.bat
@@ -14,7 +14,8 @@ if %errorlevel%==0 (
     powershell -Command "(gc %LIBRARY_LIB%\pkgconfig\gio-2.0.pc) -replace 'C:/ci_310/glib_1642686432177/_h_env/Library/lib/z.lib', '' | Out-File -encoding ASCII %LIBRARY_LIB%\pkgconfig\gio-2.0.pc"
 )
 
-meson setup builddir --wrap-mode=nofallback --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Dexamples=disabled -Dintrospection=enabled -Dtests=disabled
+:: disable introspection because of a debug warning introduced in glib 2.67.2 that breaks win64 builds; glib 2.72.2 fixes this.
+meson setup builddir --wrap-mode=nofallback --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Dexamples=disabled -Dintrospection=disabled -Dtests=disabled
 if errorlevel 1 exit 1
 
 ninja -v -C builddir -j %CPU_COUNT%

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -192,8 +192,8 @@ outputs:
         - meson
         - ninja
       host:
-        - {{ pin_subpackage('gstreamer') }}
-        - {{ pin_subpackage('gst-plugins-base') }}
+        - {{ pin_subpackage('gstreamer', exact=True) }}
+        - {{ pin_subpackage('gst-plugins-base', exact=True) }}
         - glib
         - libxcb                             # [linux]
         #- jack >=1.9.7                       # [linux64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -109,7 +109,7 @@ outputs:
         - gobject-introspection
       host:
         - {{ pin_subpackage('gstreamer', exact=True) }}
-        - glib
+        - glib 2.69.1
         - zlib
         - gettext 0.21.0                     # [not win]
         - libxcb  1.14.0                     # [linux]
@@ -141,7 +141,7 @@ outputs:
         - test -f $PREFIX/lib/girepository-1.0/GstVideo-1.0.typelib  # [unix]
         - if not exist %LIBRARY_BIN%\\gstallocators-1.0-0.dll exit 1  # [win]
         - if not exist %LIBRARY_LIB%\\girepository-1.0\\GstVideo-1.0.typelib exit 1  # [win]
-        - gst-inspect-1.0 --plugin volume
+        - GST_DEBUG=4 gst-inspect-1.0 --plugin volume
 
     about:
       summary: GStreamer Base Plug-ins

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,10 @@ source:
 
 build:
   number: 0
+  # Installing and using plugins in the conda environment isn't working for s390x, due to build options not correctly
+  # translating into the location of a helper library at runtime, for this platform.
+  # Audio/video tools aren't needed on s390x anyway.
+  skip: True # [linux and s390x]
 
 outputs:
   - name: gstreamer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -165,7 +165,8 @@ outputs:
         - $RPATH/libm.so.6  # [linux]
         - $RPATH/libpthread.so.0  # [linux]
         - $RPATH/libdl.so.2 #[linux]
-        - $RPATH/libcrypto.so.1.1 # [unix]
+        - $RPATH/libcrypto.so.1.1 # [linux]
+        - $RPATH/libcrypto.1.1.dylib # [osx]
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -118,7 +118,7 @@ outputs:
         - libopus                            # [unix]
         - libvorbis
       run:
-        - {{ pin_compatible('gstreamer') }}
+        - {{ pin_compatible('gstreamer', exact=True) }}
         - libpng                             # [unix]
         - libogg
         - gettext                            # [unix]
@@ -165,6 +165,7 @@ outputs:
         - $RPATH/libm.so.6  # [linux]
         - $RPATH/libpthread.so.0  # [linux]
         - $RPATH/libdl.so.2 #[linux]
+        - $RPATH/libcrypto.so.1.1 # [unix]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -194,18 +195,19 @@ outputs:
       host:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}
-        - glib
+        - glib 2.69.1
         - libxcb                             # [linux]
         #- jack >=1.9.7                       # [linux64]
         - lame                               # [linux]
         - mpg123                             # [linux64 or osx]
       run:
-        - {{ pin_compatible('gstreamer') }}
-        - {{ pin_subpackage('gst-plugins-base') }}
+        - {{ pin_compatible('gstreamer', exact=True) }}
+        - {{ pin_subpackage('gst-plugins-base', exact=True) }}
         - gettext                            # [osx]
         - zlib
         - libpng                             # [unix]
         - mpg123                             # [unix]
+        - libxml2 >=2.8
     test:
       commands:
         - test -f $PREFIX/lib/gstreamer-1.0/libgstalpha${SHLIB_EXT}  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -141,7 +141,7 @@ outputs:
         - test -f $PREFIX/lib/girepository-1.0/GstVideo-1.0.typelib  # [unix]
         - if not exist %LIBRARY_BIN%\\gstallocators-1.0-0.dll exit 1  # [win]
         - if not exist %LIBRARY_LIB%\\girepository-1.0\\GstVideo-1.0.typelib exit 1  # [win]
-        - GST_DEBUG=4 gst-inspect-1.0 --plugin volume
+        - gst-inspect-1.0 --plugin volume
 
     about:
       summary: GStreamer Base Plug-ins

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,7 +122,7 @@ outputs:
         - libopus 1.3                        # [unix]
         - libvorbis 1.3.7
       run:
-        - {{ pin_compatible('gstreamer', exact=True) }}
+        - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_compatible('libpng', max_pin='x.x') }} # [unix]
         - {{ pin_compatible('libogg') }}
         - {{ pin_compatible('gettext') }}               # [unix]
@@ -205,7 +205,7 @@ outputs:
         - lame 3.100                         # [linux]
         - mpg123 1.30.0                      # [linux64 or osx]
       run:
-        - {{ pin_compatible('gstreamer', exact=True) }}
+        - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}
         - {{ pin_compatible('gettext') }}    # [osx]
         - {{ pin_compatible('zlib', max_pin='x.x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.18.5" %}
+{% set version = "1.20.3" %}
 {% set posix = 'm2-' if win else '' %}
 
 package:
@@ -7,12 +7,12 @@ package:
 
 source:
   - url: https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-{{ version }}.tar.xz
-    sha256: 55862232a63459bbf56abebde3085ca9aec211b478e891dacea4d6df8cafe80a
+    sha256: 607daf64bbbd5fb18af9d17e21c0d22c4d702fffe83b23cb22d1b1af2ca23a2a
   - url: https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-{{ version }}.tar.xz
-    sha256: 960b7af4585700db0fdd5b843554e11e2564fed9e061f591fae88a7be6446fa3
+    sha256: 7e30b3dd81a70380ff7554f998471d6996ff76bbe6fc5447096f851e24473c9f
     folder: plugins_base
   - url: https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-{{ version }}.tar.xz
-    sha256: 3aaeeea7765fbf8801acce4a503a9b05f73f04e8a35352e9d00232cfd555796b
+    sha256: f8f3c206bf5cdabc00953920b47b3575af0ef15e9f871c0b6966f6d0aa5868b7
     folder: plugins_good
 
 build:
@@ -59,7 +59,7 @@ outputs:
     about:
       summary: Library for constructing graphs of media-handling components
       description:
-      doc_source_url: https://cgit.freedesktop.org/gstreamer/gstreamer/tree/docs
+      doc_source_url: https://cgit.freedesktop.org/gstreamer/gstreamer/tree/subprojects/gstreamer/docs
 
   - name: gst-plugins-base
     script: install_base_plugins.sh  # [unix]
@@ -124,6 +124,7 @@ outputs:
         - gettext                            # [unix]
         - zlib
         - libvorbis
+        - libopus                            # [unix]
     test:
       commands:
         - test -f $PREFIX/lib/libgstallocators-1.0${SHLIB_EXT}  # [unix]
@@ -148,7 +149,7 @@ outputs:
         GStreamer Base Plug-ins is a well-groomed and well-maintained collection of
         GStreamer plug-ins and elements, spanning the range of possible types of
         elements one would want to write for GStreamer.
-      doc_source_url: https://github.com/GStreamer/gst-plugins-base/tree/master/docs
+      doc_source_url: https://cgit.freedesktop.org/gstreamer/gstreamer/tree/subprojects/gst-plugins-base/docs
 
   - name: gst-plugins-good
     script: install_good_plugins.sh  # [unix]
@@ -163,6 +164,7 @@ outputs:
         - $RPATH/libc.so.6  # [linux]
         - $RPATH/libm.so.6  # [linux]
         - $RPATH/libpthread.so.0  # [linux]
+        - $RPATH/libdl.so.2 #[linux]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -222,7 +224,7 @@ outputs:
         all: good looks, good code, and good licensing.  Documented and
         dressed up in tests.  If you're looking for a role model to
         base your own plug-in on here it is.
-      doc_source_url: https://github.com/GStreamer/gst-plugins-good/tree/master/docs
+      doc_source_url: https://cgit.freedesktop.org/gstreamer/gstreamer/tree/subprojects/gst-plugins-good/docs
 
 about:
   home: https://gstreamer.freedesktop.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ outputs:
     script: install_gstreamer.sh  # [unix]
     script: install_gstreamer.bat  # [win]
     build:
-      ignore_run_exports:        # [unix]
+      ignore_run_exports:
         - gettext                # [unix]
         - glib                   # [win]
       activate_in_script: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ outputs:
         - gettext 0.21.0                    # [not win]
         - glib 2.69.1
       run:
-        - gettext                           # [not win]
+        - {{ pin_compatible('gettext') }}   # [not win]
     test:
       commands:
         - gst-inspect-1.0 --version
@@ -119,12 +119,12 @@ outputs:
         - libvorbis 1.3.7
       run:
         - {{ pin_compatible('gstreamer', exact=True) }}
-        - libpng                             # [unix]
-        - libogg
-        - gettext                            # [unix]
-        - zlib
-        - libvorbis
-        - libopus                            # [unix]
+        - {{ pin_compatible('libpng', max_pin='x.x') }} # [unix]
+        - {{ pin_compatible('libogg') }}
+        - {{ pin_compatible('gettext') }}               # [unix]
+        - {{ pin_compatible('zlib', max_pin='x.x.x') }}
+        - {{ pin_compatible('libvorbis') }}
+        - {{ pin_compatible('libopus') }}               # [unix]
     test:
       commands:
         - test -f $PREFIX/lib/libgstallocators-1.0${SHLIB_EXT}  # [unix]
@@ -198,16 +198,15 @@ outputs:
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}
         - glib 2.69.1
         - libxcb 1.14.0                      # [linux]
-        #- jack >=1.9.7                      # [linux64]
         - lame 3.100                         # [linux]
         - mpg123 1.30.0                      # [linux64 or osx]
       run:
         - {{ pin_compatible('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}
-        - gettext                            # [osx]
-        - zlib
-        - libpng                             # [unix]
-        - mpg123                             # [unix]
+        - {{ pin_compatible('gettext') }}    # [osx]
+        - {{ pin_compatible('zlib', max_pin='x.x.x') }}
+        - {{ pin_compatible('libpng', max_pin='x.x') }} # [unix]
+        - {{ pin_compatible('mpg123', max_pin='x.x') }} # [unix]
         - libxml2 >=2.8
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -160,7 +160,7 @@ outputs:
       activate_in_script: true
       run_exports:
         - {{ pin_subpackage('gst-plugins-good', max_pin='x.x') }}
-      missing_dso_whitelist:  # [linux]
+      missing_dso_whitelist:
         - $RPATH/libc.so.6  # [linux]
         - $RPATH/libm.so.6  # [linux]
         - $RPATH/libpthread.so.0  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ outputs:
         - {{ posix }}flex
         - meson
         - ninja
+        - gobject-introspection
       host:
         - gettext                           # [not win]
         - glib
@@ -106,6 +107,7 @@ outputs:
         - pkg-config
         - meson
         - ninja
+        - gobject-introspection
       host:
         - {{ pin_subpackage('gstreamer') }}
         - glib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ outputs:
     build:
       ignore_run_exports:        # [unix]
         - gettext                # [unix]
+        - glib                   # [win]
       activate_in_script: true
       run_exports:
         # remove symbols at .90 patch releases just before minor versions?
@@ -42,7 +43,6 @@ outputs:
         - {{ posix }}flex
         - meson
         - ninja
-        - gobject-introspection
       host:
         - gettext                           # [not win]
         - glib
@@ -106,7 +106,6 @@ outputs:
         - pkg-config
         - meson
         - ninja
-        - gobject-introspection
       host:
         - {{ pin_subpackage('gstreamer') }}
         - glib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,9 +23,8 @@ outputs:
     script: install_gstreamer.sh  # [unix]
     script: install_gstreamer.bat  # [win]
     build:
-      ignore_run_exports:
+      ignore_run_exports:        # [unix]
         - gettext                # [unix]
-        - glib                   # [win]
       activate_in_script: true
       run_exports:
         # remove symbols at .90 patch releases just before minor versions?

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,8 +44,8 @@ outputs:
         - ninja
         - gobject-introspection
       host:
-        - gettext                           # [not win]
-        - glib
+        - gettext 0.21.0                    # [not win]
+        - glib 2.69.1
       run:
         - gettext                           # [not win]
     test:
@@ -111,12 +111,12 @@ outputs:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - glib
         - zlib
-        - gettext                            # [not win]	
-        - libxcb                             # [linux]
-        - libpng                             # [unix]
+        - gettext 0.21.0                     # [not win]
+        - libxcb  1.14.0                     # [linux]
+        - libpng  1.6.37                     # [unix]
         #- alsa-lib                           # [linux]
-        - libopus                            # [unix]
-        - libvorbis
+        - libopus 1.3                        # [unix]
+        - libvorbis 1.3.7
       run:
         - {{ pin_compatible('gstreamer', exact=True) }}
         - libpng                             # [unix]
@@ -197,10 +197,10 @@ outputs:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}
         - glib 2.69.1
-        - libxcb                             # [linux]
-        #- jack >=1.9.7                       # [linux64]
-        - lame                               # [linux]
-        - mpg123                             # [linux64 or osx]
+        - libxcb 1.14.0                      # [linux]
+        #- jack >=1.9.7                      # [linux64]
+        - lame 3.100                         # [linux]
+        - mpg123 1.30.0                      # [linux64 or osx]
       run:
         - {{ pin_compatible('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}
@@ -234,6 +234,11 @@ about:
   summary: Library for constructing graphs of media-handling components
   license: LGPL-2.0-or-later
   license_file: COPYING
+  license_family: LGPL
+  description: |
+    The applications it supports range from simple Ogg/Vorbis playback,
+    audio/video streaming to complex audio (mixing) and video
+    (non-linear editing) processing.
   doc_url: https://gstreamer.freedesktop.org/documentation/
   dev_url: https://cgit.freedesktop.org/gstreamer/gstreamer/tree/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.20.3" %}
+{% set version = "1.22.3" %}
 {% set posix = 'm2-' if win else '' %}
 
 package:
@@ -7,12 +7,12 @@ package:
 
 source:
   - url: https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-{{ version }}.tar.xz
-    sha256: 607daf64bbbd5fb18af9d17e21c0d22c4d702fffe83b23cb22d1b1af2ca23a2a
+    sha256: 9ffeab95053f9f6995eb3b3da225e88f21c129cd60da002d3f795db70d6d5974
   - url: https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-{{ version }}.tar.xz
-    sha256: 7e30b3dd81a70380ff7554f998471d6996ff76bbe6fc5447096f851e24473c9f
+    sha256: 1c596289a0d4207380233eba8c36a932c4d1aceba19932937d9b57c24cef89f3
     folder: plugins_base
   - url: https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-{{ version }}.tar.xz
-    sha256: f8f3c206bf5cdabc00953920b47b3575af0ef15e9f871c0b6966f6d0aa5868b7
+    sha256: af81154b3a2ef3f4d2feba395f25696feea6fd13ec62c92d3c7a973470710273
     folder: plugins_good
 
 build:
@@ -108,7 +108,7 @@ outputs:
         - ninja
         - gobject-introspection
       host:
-        - {{ pin_subpackage('gstreamer') }}
+        - {{ pin_subpackage('gstreamer', exact=True) }}
         - glib
         - zlib
         - gettext                            # [not win]	

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,8 +67,8 @@ outputs:
     build:
       ignore_run_exports:
         - gettext                    # [not win]
-        - libpng                     # [linux & ppc64le]
-        - libxcb                     # [linux & ppc64le]
+        - libpng                     # [linux & (ppc64le | s390x)]
+        - libxcb                     # [linux & (ppc64le | s390x)]
         - libvorbis
         - libopus                    # [unix]
       activate_in_script: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,8 +71,8 @@ outputs:
     build:
       ignore_run_exports:
         - gettext                    # [not win]
-        - libpng                     # [linux & (ppc64le | s390x)]
-        - libxcb                     # [linux & (ppc64le | s390x)]
+        - libpng                     # [linux and ppc64le]
+        - libxcb                     # [linux and ppc64le]
         - libvorbis
         - libopus                    # [unix]
       activate_in_script: true
@@ -93,19 +93,19 @@ outputs:
         - {{ cdt('libx11-devel') }}          # [linux]
         - {{ cdt('libxrender-devel') }}      # [linux]
         - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-        - {{ cdt('mesa-libgl-devel') }}      # [linux and not s390x]
-        - {{ cdt('libdrm-devel') }}          # [linux and not s390x]
+        - {{ cdt('mesa-libgl-devel') }}      # [linux]
+        - {{ cdt('libdrm-devel') }}          # [linux]
         - {{ cdt('libxdamage-devel') }}      # [linux]
         - {{ cdt('libxfixes-devel') }}       # [linux]
         - {{ cdt('libxxf86vm-devel') }}      # [linux]
         - {{ cdt('mesa-dri-drivers') }}      # [linux]
         # These dependencies are only for cos7 platforms
-        - {{ cdt('libglvnd-glx') }}          # [linux & (ppc64le | aarch64)]
-        - {{ cdt('libglvnd') }}              # [linux & (ppc64le | aarch64)]
+        - {{ cdt('libglvnd-glx') }}          # [linux and (ppc64le | aarch64)]
+        - {{ cdt('libglvnd') }}              # [linux and (ppc64le | aarch64)]
         - {{ cdt('libxshmfence-devel') }}    # [linux and ppc64le]
-        - {{ cdt('mesa-khr-devel') }}        # [linux & (ppc64le | aarch64)]
+        - {{ cdt('mesa-khr-devel') }}        # [linux and (ppc64le | aarch64)]
         # expat here is _only_ required for mesa-dri-drivers
-        - {{ cdt('expat') }}                 # [linux and not s390x]
+        - {{ cdt('expat') }}                 # [linux]
         - {{ cdt('libselinux-devel') }}      # [linux]
         - pkg-config
         - meson
@@ -180,19 +180,19 @@ outputs:
         - {{ cdt('libx11-devel') }}          # [linux]
         - {{ cdt('libxrender-devel') }}      # [linux]
         - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-        - {{ cdt('mesa-libgl-devel') }}      # [linux and not s390x]
-        - {{ cdt('libdrm-devel') }}          # [linux and not s390x]
+        - {{ cdt('mesa-libgl-devel') }}      # [linux]
+        - {{ cdt('libdrm-devel') }}          # [linux]
         - {{ cdt('libxdamage-devel') }}      # [linux]
         - {{ cdt('libxfixes-devel') }}       # [linux]
         - {{ cdt('libxxf86vm-devel') }}      # [linux]
         - {{ cdt('mesa-dri-drivers') }}      # [linux]
         # These dependencies are only for cos7 platforms
-        - {{ cdt('libglvnd-glx') }}          # [linux & (ppc64le | aarch64)]
-        - {{ cdt('libglvnd') }}              # [linux & (ppc64le | aarch64)]
+        - {{ cdt('libglvnd-glx') }}          # [linux and (ppc64le | aarch64)]
+        - {{ cdt('libglvnd') }}              # [linux and (ppc64le | aarch64)]
         - {{ cdt('libxshmfence-devel') }}    # [linux and ppc64le]
-        - {{ cdt('mesa-khr-devel') }}        # [linux & (ppc64le | aarch64)]
+        - {{ cdt('mesa-khr-devel') }}        # [linux and (ppc64le | aarch64)]
         # expat here is _only_ required for mesa-dri-drivers
-        - {{ cdt('expat') }}                 # [linux and not s390x]
+        - {{ cdt('expat') }}                 # [linux]
         - {{ cdt('libselinux-devel') }}      # [linux]
         - pkg-config
         - meson
@@ -203,7 +203,7 @@ outputs:
         - glib 2.69.1
         - libxcb 1.14.0                      # [linux]
         - lame 3.100                         # [linux]
-        - mpg123 1.30.0                      # [linux64 or osx]
+        - mpg123 1.30.0                      # [(linux and x86_64) or osx]
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}


### PR DESCRIPTION
## Links
[changelog](https://gstreamer.freedesktop.org/releases/1.22/#1.22.3)
[upstream code](https://gitlab.freedesktop.org/gstreamer/gstreamer)

## Changes
- Update version and sha
- Fix path of zlib in glib's pkgconfig files on windows
- Skip s390x, because relocation build variables not working correctly at runtime, and video/audio stuff isn't needed anyway
- Add some missing dependencies and required dso whitelists
- pin packages in host and run
- add some "about" stuff

