### PR TITLE
build with latest glib

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -204,6 +204,8 @@ outputs:
         - libxcb 1.14.0                      # [linux]
         - lame 3.100                         # [linux]
         - mpg123 1.30.0                      # [(linux and x86_64) or osx]
+        - openssl {{ openssl }}
+        - bzip2 {{ bzip2 }}
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     folder: plugins_good
 
 build:
-  number: 0
+  number: 1
   # Installing and using plugins in the conda environment isn't working for s390x, due to build options not correctly
   # translating into the location of a helper library at runtime, for this platform.
   # Audio/video tools aren't needed on s390x anyway.
@@ -49,7 +49,7 @@ outputs:
         - gobject-introspection
       host:
         - gettext 0.21.0                    # [not win]
-        - glib 2.69.1
+        - glib {{ glib }}
       run:
         - {{ pin_compatible('gettext') }}   # [not win]
     test:
@@ -113,7 +113,7 @@ outputs:
         - gobject-introspection
       host:
         - {{ pin_subpackage('gstreamer', exact=True) }}
-        - glib 2.69.1
+        - glib {{ glib }}
         - zlib
         - gettext 0.21.0                     # [not win]
         - libxcb  1.14.0                     # [linux]
@@ -200,7 +200,7 @@ outputs:
       host:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}
-        - glib 2.69.1
+        - glib {{ glib }}
         - libxcb 1.14.0                      # [linux]
         - lame 3.100                         # [linux]
         - mpg123 1.30.0                      # [(linux and x86_64) or osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -204,6 +204,7 @@ outputs:
         - libxcb 1.14.0                      # [linux]
         - lame 3.100                         # [linux]
         - mpg123 1.30.0                      # [(linux and x86_64) or osx]
+        - libpng  1.6.37                     # [unix]
         - openssl {{ openssl }}
         - bzip2 {{ bzip2 }}
       run:


### PR DESCRIPTION
Rebuild with latest glib

We do not have gettext on windows but glib ships a proxy intl library.
The naming has changed between versions of glib. (Used to be intl.dll, is now intl-8.dll. intl-8.dll matches what would be in a gettext package.)
gstreamer happens to link to this intl library from glib.

After this is merged, the gstreamer pin for windows will have to be updated in the cbc. Only opencv depends on gstreamer on windows. 

Not trying to fix linter error on this rebuild. This can be done later on, on a gstreamer version update.