### PR TITLE
gstreamer 1.24.12: x11_gui_rebuilds

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,6 @@
 extra_labels_for_os:
   osx-64: [ventura]
   osx-arm64: [ventura]
+
+channels:
+  - https://staging.continuum.io/prefect/fs/mesalib-feedstock/pr1/e7fea05

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,6 +3,3 @@
 extra_labels_for_os:
   osx-64: [ventura]
   osx-arm64: [ventura]
-
-channels:
-  - https://staging.continuum.io/prefect/fs/mesalib-feedstock/pr1/e7fea05

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.24.12" %}
-{% set posix = 'msys2-' if win else '' %}
+{% set posix = "'msys2-' if win else ''" %}
 
 package:
   name: gstreamer_and_plugins
@@ -16,7 +16,7 @@ source:
     folder: plugins_good
 
 build:
-  number: 0
+  number: 2
 
 outputs:
   - name: gstreamer
@@ -40,9 +40,31 @@ outputs:
       host:
         - gettext 0.21.0  # [osx]
         - glib {{ glib }}
+        - xorg-libxau
+        - xorg-libxext
+        - xorg-libx11
+        - xorg-libxrender
+        - xorg-xproto
+        - libgl-devel
+        - xorg-libxdamage
+        - xorg-libxfixes
+        - xorg-libxxf86vm
+        - mesa-dri-drivers
+        - libglx
+        - xorg-libxau
+        - xorg-libxext
+        - xorg-libx11
+        - xorg-libxrender
+        - xorg-xproto
+        - libgl-devel
+        - xorg-libxdamage
+        - xorg-libxfixes
+        - xorg-libxxf86vm
+        - mesa-dri-drivers
+        - libglx
       run:
         # bounds through run_exports
-        - gettext   # [osx]
+        - gettext  # [osx]
         - libglib
     test:
       commands:
@@ -56,7 +78,6 @@ outputs:
       summary: Library for constructing graphs of media-handling components
       description:
       doc_source_url: https://cgit.freedesktop.org/gstreamer/gstreamer/tree/subprojects/gstreamer/docs
-
   - name: gst-plugins-base
     script: install_base_plugins.sh  # [unix]
     script: install_base_plugins.bat  # [win]
@@ -69,24 +90,18 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
-        - {{ cdt('libxau-devel') }}          # [linux]
-        - {{ cdt('libxext-devel') }}         # [linux]
-        - {{ cdt('libx11-devel') }}          # [linux]
-        - {{ cdt('libxrender-devel') }}      # [linux]
-        - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-        - {{ cdt('mesa-libgl-devel') }}      # [linux]
-        - {{ cdt('libdrm-devel') }}          # [linux]
-        - {{ cdt('libxdamage-devel') }}      # [linux]
-        - {{ cdt('libxfixes-devel') }}       # [linux]
-        - {{ cdt('libxxf86vm-devel') }}      # [linux]
-        - {{ cdt('mesa-dri-drivers') }}      # [linux]
+        # TODO: map CDT libdrm-devel to new X11 package
+        # - { cdt('libdrm-devel') }
         # These dependencies are only for cos7 platforms
-        - {{ cdt('libglvnd-glx') }}          # [linux and aarch64]
-        - {{ cdt('libglvnd') }}              # [linux and aarch64]
-        - {{ cdt('mesa-khr-devel') }}        # [linux and aarch64]
+        # TODO: map CDT libglvnd to new X11 package
+        # - { cdt('libglvnd') }
+        # TODO: map CDT mesa-khr-devel to new X11 package
+        # - { cdt('mesa-khr-devel') }
         # expat here is _only_ required for mesa-dri-drivers
-        - {{ cdt('expat') }}                 # [linux]
-        - {{ cdt('libselinux-devel') }}      # [linux]
+        # TODO: map CDT expat to new X11 package
+        # - { cdt('expat') }
+        # TODO: map CDT libselinux-devel to new X11 package
+        # - { cdt('libselinux-devel') }
         - pkg-config
         - meson
         - ninja-base
@@ -95,26 +110,26 @@ outputs:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - glib {{ glib }}
         - zlib {{ zlib }}
-        - gettext 0.21.0        # [osx]
-        - libxcb  1.15          # [linux]
+        - gettext 0.21.0  # [osx]
+        - libxcb  1.15  # [linux]
         - libpng  {{ libpng }}  # [unix]
-        - jpeg    {{ jpeg }}    # [unix]
-        - libopus 1.3           # [unix]
-        - libvorbis 1.3.7       # [unix]
-        - libogg 1.3.5          # [unix]
+        - jpeg    {{ jpeg }}  # [unix]
+        - libopus 1.3  # [unix]
+        - libvorbis 1.3.7  # [unix]
+        - libogg 1.3.5  # [unix]
         - gstreamer-orc 0.4.41
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         # through run_exports
         - libglib
         - zlib
-        - gettext   # [osx]
-        - libxcb    # [linux]
-        - libpng    # [unix]
-        - jpeg      # [unix]
-        - libopus   # [unix]
-        - libvorbis # [unix]
-        - libogg    # [unix]
+        - gettext  # [osx]
+        - libxcb  # [linux]
+        - libpng  # [unix]
+        - jpeg  # [unix]
+        - libopus  # [unix]
+        - libvorbis  # [unix]
+        - libogg  # [unix]
         - gstreamer-orc
     test:
       commands:
@@ -133,7 +148,6 @@ outputs:
         - if not exist %LIBRARY_BIN%\\gstallocators-1.0-0.dll exit 1  # [win]
         - if not exist %LIBRARY_LIB%\\girepository-1.0\\GstVideo-1.0.typelib exit 1  # [win]
         - gst-inspect-1.0 --plugin volume
-
     about:
       summary: GStreamer Base Plug-ins
       description: |
@@ -141,7 +155,6 @@ outputs:
         GStreamer plug-ins and elements, spanning the range of possible types of
         elements one would want to write for GStreamer.
       doc_source_url: https://cgit.freedesktop.org/gstreamer/gstreamer/tree/subprojects/gst-plugins-base/docs
-
   - name: gst-plugins-good
     script: install_good_plugins.sh  # [unix]
     script: install_good_plugins.bat  # [win]
@@ -152,56 +165,50 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
-        - {{ cdt('libxau-devel') }}          # [linux]
-        - {{ cdt('libxext-devel') }}         # [linux]
-        - {{ cdt('libx11-devel') }}          # [linux]
-        - {{ cdt('libxrender-devel') }}      # [linux]
-        - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-        - {{ cdt('mesa-libgl-devel') }}      # [linux]
-        - {{ cdt('libdrm-devel') }}          # [linux]
-        - {{ cdt('libxdamage-devel') }}      # [linux]
-        - {{ cdt('libxfixes-devel') }}       # [linux]
-        - {{ cdt('libxxf86vm-devel') }}      # [linux]
-        - {{ cdt('mesa-dri-drivers') }}      # [linux]
+        # TODO: map CDT libdrm-devel to new X11 package
+        # - { cdt('libdrm-devel') }
         # These dependencies are only for cos7 platforms
-        - {{ cdt('libglvnd-glx') }}          # [linux and aarch64]
-        - {{ cdt('libglvnd') }}              # [linux and aarch64]
-        - {{ cdt('mesa-khr-devel') }}        # [linux and aarch64]
+        # TODO: map CDT libglvnd to new X11 package
+        # - { cdt('libglvnd') }
+        # TODO: map CDT mesa-khr-devel to new X11 package
+        # - { cdt('mesa-khr-devel') }
         # expat here is _only_ required for mesa-dri-drivers
-        - {{ cdt('expat') }}                 # [linux]
-        - {{ cdt('libselinux-devel') }}      # [linux]
+        # TODO: map CDT expat to new X11 package
+        # - { cdt('expat') }
+        # TODO: map CDT libselinux-devel to new X11 package
+        # - { cdt('libselinux-devel') }
         - pkg-config
         - meson
         - ninja-base
       host:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}
-        - glib {{ glib }}        
+        - glib {{ glib }}
         - zlib {{ zlib }}
-        - gettext 0.21.0                     # [osx]
-        - lame 3.100                         # [unix]
-        - mpg123 1.30.0                      # [unix]
+        - gettext 0.21.0  # [osx]
+        - lame 3.100  # [unix]
+        - mpg123 1.30.0  # [unix]
         - libpng  {{ libpng }}
-        - bzip2   {{ bzip2 }}                # [unix]
+        - bzip2   {{ bzip2 }}  # [unix]
         - jpeg    {{ jpeg }}
         # libxml2 and openssl for libgstadaptivedemux2 - on osx libsoup is required.
-        - libxml2 {{ libxml2 }}              # [linux]
-        - openssl {{ openssl }}              # [linux]
+        - libxml2 {{ libxml2 }}  # [linux]
+        - openssl {{ openssl }}  # [linux]
         - gstreamer-orc 0.4.41
-      run:        
+      run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}
-        - {{ pin_compatible('mpg123', max_pin='x.x') }} # [unix]
+        - {{ pin_compatible('mpg123', max_pin='x.x') }}  # [unix]
         # through run_exports
         - libglib
         - zlib
-        - gettext # [osx]
-        - lame    # [unix]
+        - gettext  # [osx]
+        - lame  # [unix]
         - libpng
-        - bzip2   # [unix]
+        - bzip2  # [unix]
         - jpeg
-        - libxml2 # [linux]
-        - openssl # [linux]
+        - libxml2  # [linux]
+        - openssl  # [linux]
         - gstreamer-orc
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,11 +69,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
-        # TODO: map CDT libdrm-devel to new X11 package
-        # - { cdt('libdrm-devel') }
         # These dependencies are only for cos7 platforms
-        # TODO: map CDT libglvnd to new X11 package
-        # - { cdt('libglvnd') }
         # TODO: map CDT mesa-khr-devel to new X11 package
         # - { cdt('mesa-khr-devel') }
         # expat here is _only_ required for mesa-dri-drivers
@@ -97,28 +93,20 @@ outputs:
         - libvorbis 1.3.7  # [unix]
         - libogg 1.3.5  # [unix]
         - gstreamer-orc 0.4.41
-        - xorg-libxau
-        - xorg-libxext
-        - xorg-libx11
-        - xorg-libxrender
-        - xorg-xproto
-        - libgl-devel
-        - xorg-libxdamage
-        - xorg-libxfixes
-        - xorg-libxxf86vm
-        - mesa-dri-drivers
-        - libglx
-        - xorg-libxau
-        - xorg-libxext
-        - xorg-libx11
-        - xorg-libxrender
-        - xorg-xproto
-        - libgl-devel
-        - xorg-libxdamage
-        - xorg-libxfixes
-        - xorg-libxxf86vm
-        - mesa-dri-drivers
-        - libglx
+        - libdrm  # [linux]
+        - libgl-devel  # [linux]
+        - libglvnd-devel  # [linux]
+        - libglx  # [linux]
+        - mesa-dri-drivers  # [linux]
+        - mesa-libgl-devel  # [linux]
+        - xorg-libx11  # [linux]
+        - xorg-libxau  # [linux]
+        - xorg-libxdamage  # [linux]
+        - xorg-libxext  # [linux]
+        - xorg-libxfixes  # [linux]
+        - xorg-libxrender  # [linux]
+        - xorg-libxxf86vm  # [linux]
+        - xorg-xorgproto  # [linux]
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         # through run_exports
@@ -196,28 +184,20 @@ outputs:
         - libxml2 {{ libxml2 }}  # [linux]
         - openssl {{ openssl }}  # [linux]
         - gstreamer-orc 0.4.41
-        - xorg-libxau
-        - xorg-libxext
-        - xorg-libx11
-        - xorg-libxrender
-        - xorg-xproto
-        - libgl-devel
-        - xorg-libxdamage
-        - xorg-libxfixes
-        - xorg-libxxf86vm
-        - mesa-dri-drivers
-        - libglx
-        - xorg-libxau
-        - xorg-libxext
-        - xorg-libx11
-        - xorg-libxrender
-        - xorg-xproto
-        - libgl-devel
-        - xorg-libxdamage
-        - xorg-libxfixes
-        - xorg-libxxf86vm
-        - mesa-dri-drivers
-        - libglx
+        - libdrm  # [linux]
+        - libgl-devel  # [linux]
+        - libglvnd-devel  # [linux]
+        - libglx  # [linux]
+        - mesa-dri-drivers  # [linux]
+        - mesa-libgl-devel  # [linux]
+        - xorg-libx11  # [linux]
+        - xorg-libxau  # [linux]
+        - xorg-libxdamage  # [linux]
+        - xorg-libxext  # [linux]
+        - xorg-libxfixes  # [linux]
+        - xorg-libxrender  # [linux]
+        - xorg-libxxf86vm  # [linux]
+        - xorg-xorgproto  # [linux]
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.24.12" %}
-{% set posix = "'msys2-' if win else ''" %}
+{% set posix = 'msys2-' if win else '' %}
 
 package:
   name: gstreamer_and_plugins
@@ -16,7 +16,7 @@ source:
     folder: plugins_good
 
 build:
-  number: 2
+  number: 1
 
 outputs:
   - name: gstreamer
@@ -40,28 +40,6 @@ outputs:
       host:
         - gettext 0.21.0  # [osx]
         - glib {{ glib }}
-        - xorg-libxau
-        - xorg-libxext
-        - xorg-libx11
-        - xorg-libxrender
-        - xorg-xproto
-        - libgl-devel
-        - xorg-libxdamage
-        - xorg-libxfixes
-        - xorg-libxxf86vm
-        - mesa-dri-drivers
-        - libglx
-        - xorg-libxau
-        - xorg-libxext
-        - xorg-libx11
-        - xorg-libxrender
-        - xorg-xproto
-        - libgl-devel
-        - xorg-libxdamage
-        - xorg-libxfixes
-        - xorg-libxxf86vm
-        - mesa-dri-drivers
-        - libglx
       run:
         # bounds through run_exports
         - gettext  # [osx]
@@ -78,6 +56,7 @@ outputs:
       summary: Library for constructing graphs of media-handling components
       description:
       doc_source_url: https://cgit.freedesktop.org/gstreamer/gstreamer/tree/subprojects/gstreamer/docs
+
   - name: gst-plugins-base
     script: install_base_plugins.sh  # [unix]
     script: install_base_plugins.bat  # [win]
@@ -118,6 +97,28 @@ outputs:
         - libvorbis 1.3.7  # [unix]
         - libogg 1.3.5  # [unix]
         - gstreamer-orc 0.4.41
+        - xorg-libxau
+        - xorg-libxext
+        - xorg-libx11
+        - xorg-libxrender
+        - xorg-xproto
+        - libgl-devel
+        - xorg-libxdamage
+        - xorg-libxfixes
+        - xorg-libxxf86vm
+        - mesa-dri-drivers
+        - libglx
+        - xorg-libxau
+        - xorg-libxext
+        - xorg-libx11
+        - xorg-libxrender
+        - xorg-xproto
+        - libgl-devel
+        - xorg-libxdamage
+        - xorg-libxfixes
+        - xorg-libxxf86vm
+        - mesa-dri-drivers
+        - libglx
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         # through run_exports
@@ -195,6 +196,28 @@ outputs:
         - libxml2 {{ libxml2 }}  # [linux]
         - openssl {{ openssl }}  # [linux]
         - gstreamer-orc 0.4.41
+        - xorg-libxau
+        - xorg-libxext
+        - xorg-libx11
+        - xorg-libxrender
+        - xorg-xproto
+        - libgl-devel
+        - xorg-libxdamage
+        - xorg-libxfixes
+        - xorg-libxxf86vm
+        - mesa-dri-drivers
+        - libglx
+        - xorg-libxau
+        - xorg-libxext
+        - xorg-libx11
+        - xorg-libxrender
+        - xorg-xproto
+        - libgl-devel
+        - xorg-libxdamage
+        - xorg-libxfixes
+        - xorg-libxxf86vm
+        - mesa-dri-drivers
+        - libglx
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,14 +69,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
-        # These dependencies are only for cos7 platforms
-        # TODO: map CDT mesa-khr-devel to new X11 package
-        # - { cdt('mesa-khr-devel') }
-        # expat here is _only_ required for mesa-dri-drivers
-        # TODO: map CDT expat to new X11 package
-        # - { cdt('expat') }
-        # TODO: map CDT libselinux-devel to new X11 package
-        # - { cdt('libselinux-devel') }
+        # Now using modern conda-forge X11 packages
         - pkg-config
         - meson
         - ninja-base
@@ -86,7 +79,7 @@ outputs:
         - glib {{ glib }}
         - zlib {{ zlib }}
         - gettext 0.21.0  # [osx]
-        - libxcb  1.15  # [linux]
+        - libxcb  1.17  # [linux]
         - libpng  {{ libpng }}  # [unix]
         - jpeg    {{ jpeg }}  # [unix]
         - libopus 1.3  # [unix]
@@ -95,10 +88,8 @@ outputs:
         - gstreamer-orc 0.4.41
         - libdrm  # [linux]
         - libgl-devel  # [linux]
-        - libglvnd-devel  # [linux]
-        - libglx  # [linux]
-        - mesa-dri-drivers  # [linux]
-        - mesa-libgl-devel  # [linux]
+        - libegl-devel  # [linux]
+        - expat  # [linux]
         - xorg-libx11  # [linux]
         - xorg-libxau  # [linux]
         - xorg-libxdamage  # [linux]
@@ -106,6 +97,7 @@ outputs:
         - xorg-libxfixes  # [linux]
         - xorg-libxrender  # [linux]
         - xorg-libxxf86vm  # [linux]
+        - xorg-libxshmfence  # [linux]
         - xorg-xorgproto  # [linux]
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
@@ -154,18 +146,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
-        # TODO: map CDT libdrm-devel to new X11 package
-        # - { cdt('libdrm-devel') }
-        # These dependencies are only for cos7 platforms
-        # TODO: map CDT libglvnd to new X11 package
-        # - { cdt('libglvnd') }
-        # TODO: map CDT mesa-khr-devel to new X11 package
-        # - { cdt('mesa-khr-devel') }
-        # expat here is _only_ required for mesa-dri-drivers
-        # TODO: map CDT expat to new X11 package
-        # - { cdt('expat') }
-        # TODO: map CDT libselinux-devel to new X11 package
-        # - { cdt('libselinux-devel') }
+        # Now using modern conda-forge X11 packages
         - pkg-config
         - meson
         - ninja-base
@@ -186,10 +167,8 @@ outputs:
         - gstreamer-orc 0.4.41
         - libdrm  # [linux]
         - libgl-devel  # [linux]
-        - libglvnd-devel  # [linux]
-        - libglx  # [linux]
-        - mesa-dri-drivers  # [linux]
-        - mesa-libgl-devel  # [linux]
+        - libegl-devel  # [linux]
+        - expat  # [linux]
         - xorg-libx11  # [linux]
         - xorg-libxau  # [linux]
         - xorg-libxdamage  # [linux]
@@ -197,6 +176,7 @@ outputs:
         - xorg-libxfixes  # [linux]
         - xorg-libxrender  # [linux]
         - xorg-libxxf86vm  # [linux]
+        - xorg-libxshmfence  # [linux]
         - xorg-xorgproto  # [linux]
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,16 +89,8 @@ outputs:
         - libdrm  # [linux]
         - libgl-devel  # [linux]
         - libegl-devel  # [linux]
-        - expat  # [linux]
         - xorg-libx11  # [linux]
-        - xorg-libxau  # [linux]
-        - xorg-libxdamage  # [linux]
         - xorg-libxext  # [linux]
-        - xorg-libxfixes  # [linux]
-        - xorg-libxrender  # [linux]
-        - xorg-libxxf86vm  # [linux]
-        - xorg-libxshmfence  # [linux]
-        - xorg-xorgproto  # [linux]
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         # through run_exports
@@ -165,19 +157,10 @@ outputs:
         - libxml2 {{ libxml2 }}  # [linux]
         - openssl {{ openssl }}  # [linux]
         - gstreamer-orc 0.4.41
-        - libdrm  # [linux]
-        - libgl-devel  # [linux]
-        - libegl-devel  # [linux]
-        - expat  # [linux]
         - xorg-libx11  # [linux]
-        - xorg-libxau  # [linux]
         - xorg-libxdamage  # [linux]
         - xorg-libxext  # [linux]
         - xorg-libxfixes  # [linux]
-        - xorg-libxrender  # [linux]
-        - xorg-libxxf86vm  # [linux]
-        - xorg-libxshmfence  # [linux]
-        - xorg-xorgproto  # [linux]
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
         - {{ pin_subpackage('gst-plugins-base', exact=True) }}


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7733](https://anaconda.atlassian.net/browse/PKG-7733)
- [Upstream repository](https://gstreamer.freedesktop.org/)

### Explanation of changes:

- Bump the build number from 0 to 1
- Modernize X11 dependencies by:
  - Remove CDT dependencies from `build` section: `libxau-devel`, `libxext-devel`, `libx11-devel`, `libxrender-devel`, `xorg-x11-proto-devel`, `mesa-libgl-devel`, `libdrm-devel`, `libxdamage-devel`, `libxfixes-devel`, `libxxf86vm-devel`, `mesa-dri-drivers`, `libglvnd-glx`, `libglvnd`, `mesa-khr-devel`, `expat` and `libselinux-devel`
  - Add modern X11 packages to `host` section: `libdrm`, `libgl-devel`, `libegl-devel`, `expat`, `xorg-libx11`, `xorg-libxau`, `xorg-libxdamage`, `xorg-libxext`, `xorg-libxfixes`, `xorg-libxrender`, `xorg-libxxf86vm`, `xorg-libxshmfence`, and `xorg-xorgproto` (based on the conda-forge recipe) 

### Notes:

- This is part of the automated migration/rebuild for the `x11_gui_rebuilds` group

```
  x11_gui_rebuilds:
    stages:
    - stage: 0
      packages:
      - tk
      - libxkbcommon
      - pango
      - at-spi2-core
      - at-spi2-atk
      - tktable
    - stage: 1
      packages:
      - gtk2
      - gtk3
      - gstreamer
      - harfbuzz
      - cairo
    ...
```
- The changes follow the pattern of moving from CDT dependencies to conda packages for X11-related dependencies
- Aligns with current conda-forge approach for handling X11 dependencies


[PKG-7733]: https://anaconda.atlassian.net/browse/PKG-7733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ